### PR TITLE
reference original

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ type WiFiMessage =
 	| "station_disconnect";
 
 /**
- * WiFiConnectionManager is designed to be used in place of the "wifi" module in project, that need a continuously available connection to a Wi-Fi access point.
+ * WiFiConnectionManager is designed to be used in place of the "wifi" module in projects that need a continuously available connection to a Wi-Fi access point.
  *
  * - If no connection available at start, retries until one is.
  * - Automatically attempts to reconnect when connection dropped.
@@ -47,7 +47,10 @@ type WiFiMessage =
  *   }
  * );
  * ```
- */
+ * 
+ * This code is based on the Wi-Fi Connection example in the Moddable SDK:
+ *     https://github.com/Moddable-OpenSource/moddable/blob/public/examples/network/wifi/wificonnection/wificonnection.js
+*/
 export class WiFiConnectionManager extends WiFi {
 	private reconnectTimer?: Timer;
 	private connectionTimer?: Timer;


### PR DESCRIPTION
Nice work migrating the Wi-Fi Connection example to TypeScript!

When reading code, I find it helpful to know the origin. It sometimes helps when I have questions about how it works. I've added that here along with a very minor correction.